### PR TITLE
docs: map replacement jumps to the start of an actual line in recommendation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog][changelog], and this project adheres t
 ### Documentation
 
 - Include a demonstration video to showcase motions that open the window.
+- Map replacement jumps to the start of an actual line in recommendation.
 
 ### Maintenance
 

--- a/README.md
+++ b/README.md
@@ -48,4 +48,6 @@ vim.keymap.set("n", "0", "g0")
 vim.keymap.set("v", "0", "g0")
 vim.keymap.set("n", "g$", "$")
 vim.keymap.set("v", "g$", "$")
+vim.keymap.set("n", "g0", "0")
+vim.keymap.set("v", "g0", "0")
 ```


### PR DESCRIPTION
when `wrap` is set and the cursor ventures too far from the start of line it wasn't so quick to go back to the beginning!