### PR TITLE
chore(ci): move nix jobs to self-hosted runners

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -9,7 +9,7 @@ jobs:
   dependabot:
     name: Merge automatic pull requests
     if: github.actor == 'dependabot[bot]'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 12
     permissions:
       actions: write
@@ -31,8 +31,6 @@ jobs:
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-      - name: Install a flaked Nix
-        uses: DeterminateSystems/nix-installer-action@c5a866b6ab867e88becbed4467b93592bce69f8a # v21
       - name: Start the tests
         run: |
           gh api \
@@ -73,7 +71,7 @@ jobs:
   flake:
     name: Freeze the latest lockfile
     if: github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       actions: write
       contents: write
@@ -87,8 +85,6 @@ jobs:
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-      - name: Install a flaked Nix
-        uses: DeterminateSystems/nix-installer-action@c5a866b6ab867e88becbed4467b93592bce69f8a # v21
       - name: Checkout an update
         run: |
           git checkout -b update

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     name: Opens to the right page
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       contents: read
     steps:
@@ -17,7 +17,5 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Install a flaked Nix
-        uses: DeterminateSystems/nix-installer-action@c5a866b6ab867e88becbed4467b93592bce69f8a # v21
       - name: Run tests
         run: nix develop -c make test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog][changelog], and this project adheres t
 ### Maintenance
 
 - Require changes to the changelog before merging changes of development.
+- Run Nix-based automation on self-hosted runners without installer setup.
 - Use the minimum set of permissions required in pinned workflow actions.
 - Update dependencies and package with a program on a regular scheduling.
 - Package a nix distribution within the project flake file to share back.


### PR DESCRIPTION
## Summary
- move Nix-based jobs from `ubuntu-latest`/`macos-latest` onto self-hosted runners
- remove `DeterminateSystems/nix-installer-action` from those jobs
- keep lightweight non-Nix jobs on hosted runners

## Notes
This follows the self-hosted runner migration pattern while leaving jobs like changelog/licensure/other non-Nix checks on hosted runners.