### PR TITLE
ci: use tom runner label for self-hosted jobs

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -9,7 +9,7 @@ jobs:
   dependabot:
     name: Merge automatic pull requests
     if: github.actor == 'dependabot[bot]'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 12
     permissions:
       actions: write
@@ -31,8 +31,6 @@ jobs:
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-      - name: Install a flaked Nix
-        uses: DeterminateSystems/nix-installer-action@c5a866b6ab867e88becbed4467b93592bce69f8a # v21
       - name: Start the tests
         run: |
           gh api \
@@ -73,7 +71,7 @@ jobs:
   flake:
     name: Freeze the latest lockfile
     if: github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       actions: write
       contents: write
@@ -87,8 +85,6 @@ jobs:
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-      - name: Install a flaked Nix
-        uses: DeterminateSystems/nix-installer-action@c5a866b6ab867e88becbed4467b93592bce69f8a # v21
       - name: Checkout an update
         run: |
           git checkout -b update

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -9,7 +9,7 @@ jobs:
   dependabot:
     name: Merge automatic pull requests
     if: github.actor == 'dependabot[bot]'
-    runs-on: self-hosted
+    runs-on: tom
     timeout-minutes: 12
     permissions:
       actions: write
@@ -71,7 +71,7 @@ jobs:
   flake:
     name: Freeze the latest lockfile
     if: github.event_name != 'pull_request'
-    runs-on: self-hosted
+    runs-on: tom
     permissions:
       actions: write
       contents: write

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     name: Opens to the right page
-    runs-on: self-hosted
+    runs-on: tom
     permissions:
       contents: read
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     name: Opens to the right page
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       contents: read
     steps:
@@ -17,7 +17,5 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Install a flaked Nix
-        uses: DeterminateSystems/nix-installer-action@c5a866b6ab867e88becbed4467b93592bce69f8a # v21
       - name: Run tests
         run: nix develop -c make test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog][changelog], and this project adheres t
 - Replace handle with authorship of drafted publication for updates more.
 
 ### Maintenance
+- Migrate nix dependent workflows to use self hosted runner machines.
 
 - Require changes to the changelog before merging changes of development.
 - Use the minimum set of permissions required in pinned workflow actions.


### PR DESCRIPTION
Updates self-hosted runner references to use the `tom` label.