### PR TITLE
ci: test updates inline to avoid overhead of multiple pending runner at once

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -33,24 +33,7 @@ jobs:
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
       - name: Start the tests
         run: |
-          gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "/repos/$REPO/actions/workflows/tests.yml/dispatches" \
-             -f "ref=$REF"
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REF: ${{ github.head_ref }}
-          REPO: ${{ github.repository }}
-      - name: Wait for tests to succeed
-        uses: lewagon/wait-on-check-action@9312864dfbc9fd208e9c0417843430751c042800 # v1.7.0
-        with:
-          allowed-conclusions: success
-          check-name: "Opens to the right page"
-          ref: ${{ github.head_ref }}
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 10
+          nix develop -c make test
       - name: Merge requests from the kind dependabot
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
         run: gh pr merge --auto --squash "$PR_URL"
@@ -111,24 +94,7 @@ jobs:
       - name: Start the tests
         if: steps.diff.outputs.changed == 'true'
         run: |
-          gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "/repos/$REPO/actions/workflows/tests.yml/dispatches" \
-             -f "ref=update"
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-      - name: Wait for tests to succeed
-        if: steps.diff.outputs.changed == 'true'
-        uses: lewagon/wait-on-check-action@9312864dfbc9fd208e9c0417843430751c042800 # v1.7.0
-        with:
-          allowed-conclusions: success
-          check-name: "Opens to the right page"
-          ref: update
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 10
+          nix develop -c make test
       - name: Save changed version
         if: steps.diff.outputs.changed == 'true'
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog][changelog], and this project adheres t
 
 ### Maintenance
 
+- Test dependency updates inline to avoid overhead of multiple pending runner at once.
 - Require changes to the changelog before merging changes of development.
 - Use the minimum set of permissions required in pinned workflow actions.
 - Update dependencies and package with a program on a regular scheduling.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,13 @@ The format is based on [Keep a Changelog][changelog], and this project adheres t
 
 ### Maintenance
 
-- Test dependency updates inline to avoid overhead of multiple pending runner at once.
 - Require changes to the changelog before merging changes of development.
 - Use the minimum set of permissions required in pinned workflow actions.
 - Update dependencies and package with a program on a regular scheduling.
 - Package a nix distribution within the project flake file to share back.
 - Overwrite failed attempts to update dependencies after pauses for hour.
 - Prefer self hosted nix installation for test runner package management.
+- Test updates to dependencies in same scripts as the update for concise.
 
 ## [0.1.0] - 2025-04-02
 


### PR DESCRIPTION
The `lewagon/wait-on-check-action` composite action uses `ruby/setup-ruby` internally, which fails on the self-hosted NixOS runner.

This replaces the dependency workflow's dispatch-and-wait pattern with direct inline execution, so dependency update validation happens in the same workflow instead of spawning extra pending runs.